### PR TITLE
change github api for commits in pulls

### DIFF
--- a/src/main/scala/backend/PullRequestChecker.scala
+++ b/src/main/scala/backend/PullRequestChecker.scala
@@ -55,7 +55,7 @@ class PullRequestChecker(ghapi: GithubAPI, jobBuilderProps: Props) extends Actor
       } yield comment.created_at
       // TODO - Check commit times, so we rebuild on new commits.
       // val newCommits = <search commits for last updated time>
-      val commitTimes = commits map (_.committer.date)
+      val commitTimes = commits map (_.commit.committer.date)
       (created ++ requests ++ commitTimes).max
     }
     

--- a/src/main/scala/rest/github/api.scala
+++ b/src/main/scala/rest/github/api.scala
@@ -66,9 +66,9 @@ trait API {
     Http(action)
   }
 
-  def pullrequestcommits(user: String, repo: String, number: String): List[CommitInfo] = {
+  def pullrequestcommits(user: String, repo: String, number: String): List[PRCommit] = {
     val url = makeAPIurl("/repos/%s/%s/pulls/%s/commits?per_page=100" format (user,repo,number))
-    val action = url >- parseJsonTo[List[CommitInfo]]
+    val action = url >- parseJsonTo[List[PRCommit]]
     Http(action)
   }
 
@@ -167,19 +167,16 @@ case class GitRef(
   def sha10 = sha take 10
 }
 
-case class CommitInfo(
+case class PRCommit(
   url: String,
-  sha: String,
-  message: String,
-  committer: CommitAuthor,
-  author: CommitAuthor,
-  parents: List[CommitRef],
-  tree: CommitRef
+  commit: CommitInfo
 )
 
-case class CommitRef(
-  sha: String,
-  url: String)
+case class CommitInfo(
+  committer: CommitAuthor,
+  author: CommitAuthor,
+  message: String
+)
 
 case class CommitAuthor(
   email: String,


### PR DESCRIPTION
apparently github changed their api again
this commit updates `pullrequestcommits` to return a list of `PRCommit`s
this type was formerly called `CommitInfo`
a new class `CommitInfo` is introduced as the type
for `PRCommit`'s `commit` member

also remove unused fields to reduce our exposure to future api changes

review by @jsuereth, @dotta
