### PR TITLE
Rebuild respect timing

### DIFF
--- a/src/main/scala/backend/PullRequestCommenter.scala
+++ b/src/main/scala/backend/PullRequestCommenter.scala
@@ -70,7 +70,6 @@ class PullRequestCommenter(ghapi: GithubAPI, pull: rest.github.Pull, job: Jenkin
             needsAttention()
 
             import dispatch._
-
             val consoleOutput = Http(url(status.url) / "consoleText" >- identity[String])
             val (log, failureLog) = consoleOutput.lines.span(! _.startsWith("BUILD FAILED"))
 


### PR DESCRIPTION
1. show the commit hash from the build log is build was succesful so that we can double check it was indeed building the most recent commit
2. this fixes an issue where we didn't start new jobs if there already was one in the jenkins queue... now we always start a new job when asked, but also watch previously running jobs to report about their results

every time the build kitten is restarted, it'll start new jobs for all PRs that require it (PLS REBUILD ALL or more recent commit). 

TODO: add UID to jenkins job, parse jenkins job started comments and link them up that way -- timing is not reliable

for now, we can live with an overeager kitten (only comes up at reboot)

review by @jsuereth
