### PR TITLE
leniency for https

### DIFF
--- a/src/main/scala/rest/package.scala
+++ b/src/main/scala/rest/package.scala
@@ -11,7 +11,7 @@ package object rest {
 
   /** May be used directly from any thread. */
   import org.apache.http.auth.AuthScope
-  object Http extends LoggingHttp with NoLogging with thread.Safety {
+  object Http extends LoggingHttp with NoLogging with thread.Safety with HttpsLeniency {
     type CurrentCredentials = util.DynamicVariable[Option[(AuthScope, Credentials)]]
     // https://groups.google.com/forum/#!topic/dispatch-scala/RCtWZ5ZJuYo/discussion
     import org.apache.http.params.CoreConnectionPNames


### PR DESCRIPTION
This should hopefully fix

```
javax.net.ssl.SSLException: hostname in certificate didn't match: <jenkins.akka.io> != <*.typesafe.com> OR <*.typesafe.com> OR <typesafe.com>
        at org.apache.http.conn.ssl.AbstractVerifier.verify(AbstractVerifier.java:228)
<snip>
        at dispatch.classic.Http.apply(Http.scala:21)
        at backend.PullRequestCommenter$$anonfun$receive$1.applyOrElse(PullRequestCommenter.scala:51)
```

seen in https://github.com/akka/akka/pull/1381
